### PR TITLE
Add a warning to configTzTime saying it can only be called once

### DIFF
--- a/cores/esp32/esp32-hal-time.c
+++ b/cores/esp32/esp32-hal-time.c
@@ -63,6 +63,7 @@ void configTime(long gmtOffset_sec, int daylightOffset_sec, const char* server1,
 /*
  * configTzTime
  * sntp setup using TZ environment variable
+ * NOTE: this function cannot be reliably called more than once, see https://github.com/espressif/esp-idf/issues/3046
  * */
 void configTzTime(const char* tz, const char* server1, const char* server2, const char* server3)
 {


### PR DESCRIPTION
Add a warning about side-effects of using this function

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

### Checklist
1. [x] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [x] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [?] Please **update relevant Documentation** if applicable
4. [x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change
Unsuspecting users of configTzTime are likely to encounter a crash if they try to call it multiple times.

## Tests scenarios
Please describe on what Hardware and Software combinations you have tested this Pull Request and how.

(*eg. I have tested my Pull Request on Arduino-esp32 core v2.0.2 with ESP32 and ESP32-S2 Board with this scenario*)

## Related links
Please provide links to related issue, PRs etc.
https://github.com/espressif/esp-idf/issues/3046

(*eg. Closes #number of issue*)
